### PR TITLE
FIX: enable download of JR1 reports by clicking link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ credentials.json
 usage.json
 
 \.vscode/
+.idea/
 
 .nuxt/

--- a/client/components/Report.vue
+++ b/client/components/Report.vue
@@ -66,7 +66,7 @@
               <tr v-if="category !== 'rejets'">
                 <td>{{ item[0] }}</td>
                 <td v-if="isLink(item[1])" class="text-xs-left">
-                  <a :href="localePath(item[1])" target="_blank" v-text="item[1]" />
+                  <a :href="localePath(`/${item[1]}`)" target="_blank" v-text="item[1]" />
                 </td>
                 <td v-else class="text-left" v-text="item[1]" />
               </tr>
@@ -81,7 +81,7 @@
                 <td v-else v-text="item[0]" />
 
                 <td v-if="isLink(item[1])" class="text-left">
-                  <a :href="localePath(item[1])" target="_blank" v-text="item[1]" />
+                  <a :href="localePath(`/${item[1]}`)" target="_blank" v-text="item[1]" />
                 </td>
                 <td v-else class="text-left" v-text="item[1]" />
 


### PR DESCRIPTION
Once the ezPAARSE processes have finalized, the report UI displays clickable links to download and view trace, processed logs files, JR1 reports. However, the `href=` attributes fail to populate during page build.

This PR attempts to resolve the issue by populating the `href=` values; thus, enabling reports to be downloaded with a click and reducing end user confusion.

Closes #102 