### PR TITLE
Revert "FIX: enable download of JR1 reports by clicking link"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ credentials.json
 usage.json
 
 \.vscode/
+.idea
 
 .nuxt/

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,6 @@ credentials.json
 usage.json
 
 \.vscode/
-.idea
+.idea/
 
 .nuxt/

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,5 @@ credentials.json
 usage.json
 
 \.vscode/
-.idea/
 
 .nuxt/

--- a/client/components/Report.vue
+++ b/client/components/Report.vue
@@ -66,7 +66,7 @@
               <tr v-if="category !== 'rejets'">
                 <td>{{ item[0] }}</td>
                 <td v-if="isLink(item[1])" class="text-xs-left">
-                  <a :href="localePath(`/${item[1]}`)" target="_blank" v-text="item[1]" />
+                  <a :href="localePath(item[1])" target="_blank" v-text="item[1]" />
                 </td>
                 <td v-else class="text-left" v-text="item[1]" />
               </tr>
@@ -81,7 +81,7 @@
                 <td v-else v-text="item[0]" />
 
                 <td v-if="isLink(item[1])" class="text-left">
-                  <a :href="localePath(`/${item[1]}`)" target="_blank" v-text="item[1]" />
+                  <a :href="localePath(item[1])" target="_blank" v-text="item[1]" />
                 </td>
                 <td v-else class="text-left" v-text="item[1]" />
 

--- a/client/components/Report.vue
+++ b/client/components/Report.vue
@@ -66,7 +66,7 @@
               <tr v-if="category !== 'rejets'">
                 <td>{{ item[0] }}</td>
                 <td v-if="isLink(item[1])" class="text-xs-left">
-                  <a :href="localePath(item[1])" target="_blank" v-text="item[1]" />
+                  <a :href="item[1]" target="_blank" v-text="item[1]" />
                 </td>
                 <td v-else class="text-left" v-text="item[1]" />
               </tr>
@@ -81,7 +81,7 @@
                 <td v-else v-text="item[0]" />
 
                 <td v-if="isLink(item[1])" class="text-left">
-                  <a :href="localePath(item[1])" target="_blank" v-text="item[1]" />
+                  <a :href="item[1]" target="_blank" v-text="item[1]" />
                 </td>
                 <td v-else class="text-left" v-text="item[1]" />
 


### PR DESCRIPTION
Reverts ezpaarse-project/ezpaarse#103

Hello @dzoladz,
Thank you for your contribution. Alas, I've merged it too quickly.
The problem with the links comes from the ``localePath`` function, inadvertently introduced during the translation system update and that should not be used.
Your modification thus causes the new link to be ``http://localhost:59599/http://localhost:59599/<jobId>``

The ``localePath`` function is generally used on the ezPAARSE interface (it builds the links by adding the locale or not depending on the language). in this specific case, the ``http://localhost:59599/<jobId>`` url is wired to the API and doesn't need to know the language used on the interface.

Bests.

@wilmouths 