### PR TITLE
#127: Sync README.md docker instructions with doc/start/install.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Then, you can run the dockerized ezpaarse this way:
 ```
 mkdir ezpaarse/
 wget --no-check-certificate https://raw.githubusercontent.com/ezpaarse-project/ezpaarse/master/docker-compose.yml
+test -f config.local.json || echo '{}' > config.local.json
 docker-compose up -d
 ```
 


### PR DESCRIPTION
Fix #127 for README.md